### PR TITLE
add module number to congrats module

### DIFF
--- a/Do1Thing/data/ModuleContent.js
+++ b/Do1Thing/data/ModuleContent.js
@@ -126,6 +126,7 @@ const modules = [
             {
                 pageType: 'ModuleCongrats',
                 buttonText: 'Done',
+                module: 1,
                 content: {
                     info: 'You went through all the materials for Module 1, hopefully you learned a bit more about how to make a plan.',
                     image: require('../assets/module1/Congratulations_Image.png'),


### PR DESCRIPTION
Seems somewhere during the pull requests a change was introduced that broke badges. This PR fixes it.